### PR TITLE
Removes auto-completed closing tag

### DIFF
--- a/dash/app-shell.html
+++ b/dash/app-shell.html
@@ -199,7 +199,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                              route="{{subroute}}"></view-personalized>
           <view-hact route="{{subroute}}"
                      class="page"
-                     display-detail="{{displayDetail}}"></view-hact>
+                     display-detail="{{displayDetail}}"
                      user="[[user]]"
                      name="hact"></view-hact>
           <view-partnerships route="{{route}}"


### PR DESCRIPTION
An extra closing tag made its way into develop. This removes it.