### PR TITLE
Allows partnerships loading spinner to disappear when no partnerships on personalized dash

### DIFF
--- a/dash/app/views/personalized/view-personalized.html
+++ b/dash/app/views/personalized/view-personalized.html
@@ -353,7 +353,7 @@
       }
 
       _checkPartnershipsData(data) {
-        if ((data && data.length) || !data) {
+        if ((data && data.length) || !data.length) {
           this.set('partnershipsLoaded', true);
         }
       }


### PR DESCRIPTION
[ch6290]