### PR TITLE
Fixes subroute glitch between hact and partnerships tabs

### DIFF
--- a/dash/app-shell.html
+++ b/dash/app-shell.html
@@ -117,6 +117,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                data="{{routeData}}"
                tail="{{subroute}}">
     </app-route>
+    <app-route route="{{subroute}}"
+               pattern="/:tab"
+               data="{{subrouteData}}"></app-route>
 
     <app-drawer-layout id="layout" force-narrow fullbleed>
       <!-- Main content -->
@@ -235,19 +238,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                      display-detail="{{displayDetail}}"
                      user="[[user]]"
                      name="hact"></view-hact>
-          <view-partnerships route="{{route}}"
+          <view-partnerships route="{{subroute}}"
                              class="page"
                              name="partnerships"
                              csv-download-url="{{csvUrl}}"></view-partnerships>
-          <view-trips route="{{route}}"
+          <view-trips route="{{subroute}}"
                       class="page"
                       name="trips"
                       user="[[user]]"></view-trips>
-          <view-map route="{{route}}"
+          <view-map route="{{subroute}}"
                     user="[[user]]"
                     class="page"
                     name="map"></view-map>
-          <view-attachments route="{{route}}"
+          <view-attachments route="{{subroute}}"
                             class="page"
                             name="attachments"></view-attachments>
         </iron-pages>
@@ -289,7 +292,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             observer: '_pageChanged'
           },
           routeData: Object,
-          subroute: Object,
           // This shouldn't be neccessary, but the Analyzer isn't picking up
           // Polymer.Element#rootPath
           rootPath: String,

--- a/dash/app/views/hact/view-hact.html
+++ b/dash/app/views/hact/view-hact.html
@@ -130,7 +130,7 @@
       }
     </style>
 
-    <app-route route="{{route}}"
+    <app-route route="[[route]]"
                pattern="/:hactTab"
                data="{{routeData}}"
                active="{{hactActive}}"
@@ -296,7 +296,8 @@
             notify: true
           },
           route: {
-            type: Object
+            type: Object,
+            notify: true
           },
           user: {
             type: Object
@@ -304,7 +305,6 @@
           hactActive: {
             type: Boolean
           }
-
         };
       }
 
@@ -355,7 +355,7 @@
           this.updateAppState(this.route.prefix+this.route.path);
           this.$.assurancePlan.classList.add('dark-button');
           this.$.dashboardCharts.classList.add('light-button');
-        } else {
+        } else if (tab === 'assurance') {
           this.updateAppState(this.route.prefix+this.route.path+'?'+this.buildQueryString());
           this.$.assurancePlan.classList.remove('dark-button');
           this.$.dashboardCharts.classList.remove('light-button');

--- a/dash/app/views/partnerships/data/partnership-data.html
+++ b/dash/app/views/partnerships/data/partnership-data.html
@@ -4,7 +4,6 @@
 <link rel="import" href="../../../mixins/event-helper-mixin.html">
 <link rel="import" href="../../../config/dexie-db-config.html">
 
-
 <dom-module id="partnership-data">
 
   <script>
@@ -125,6 +124,8 @@
         if (this.active) {
           this.fireEvent('global-loading', { message: 'Loading partnerships data...', active: true, loadingSource: 'partnership-data' });
           this.set('loadedInitially', true);
+        } else {
+          this.fireEvent('global-loading', { active: false, loadingSource: 'partnership-data' })
         }
       }
 
@@ -183,7 +184,6 @@
               ...this.presetResults.map(res => res.sortBy(sortBy || 'partner_name'))
             ]);
           }).then(countAndResult => {
-            this.fireEvent('global-loading', { loadingSource: 'partnership-data' });
             this._setTotalResults(countAndResult[0]);
             this._setFilteredPartnerships(countAndResult[1]);
             let presetFilterResults = countAndResult.slice(2)
@@ -196,6 +196,7 @@
             } else {
               this.set('presetsLoaded', true)
             };
+            this.fireEvent('global-loading', {loadingSource: 'partnership-data'});
           }).catch(err => console.error('Error querying partnerships-dash: ', err));
       }
     }

--- a/dash/app/views/partnerships/data/partnership-overview-data.html
+++ b/dash/app/views/partnerships/data/partnership-overview-data.html
@@ -3,7 +3,6 @@
 <link rel="import" href="../../../mixins/event-helper-mixin.html">
 <link rel="import" href="../../../config/dexie-db-config.html">
 
-
 <dom-module id="partnership-overview-data">
 
   <script>
@@ -157,7 +156,6 @@
               ...this.presetResults.map(res => res.sortBy(sortBy || 'name'))
             ]);
           }).then(countAndResult => {
-            this.fireEvent('global-loading', { loadingSource: 'partnership-overview-data' });
             this._setTotalResults(countAndResult[0]);
             this._setFilteredPartnershipsOverview(countAndResult[1]);
             this.set('allPartners', countAndResult[2]);
@@ -171,6 +169,7 @@
             } else {
               this.set('presetsLoaded', true)
             };
+            this.fireEvent('global-loading', {loadingSource: 'partnership-overview-data'});
           }).catch(err => console.error('Error querying partnerships-overview: ', err));
       }
     }

--- a/dash/app/views/partnerships/elements/cso-dashboard.html
+++ b/dash/app/views/partnerships/elements/cso-dashboard.html
@@ -832,10 +832,9 @@
 
       _updateUrl(query, pageNumber, pageSize, sortOrder, orderBy, requiredDataLoaded,
         initComplete, selectedSectors, selectedOffices, selectedStatuses, startAfterDate, endBeforeDate, startBeforeDate, endAfterDate) {
-          if (!this.initComplete || !this.requiredDataLoaded) {
+          if (!this.active || !this.initComplete || !this.requiredDataLoaded) {
           return;
         }
-
         this.set('csvDownloadUrl', this._buildCsvDownloadUrl());
         const qs = this.buildQueryString();
         const currentRoute = this.route.prefix + this.route.path;

--- a/dash/app/views/partnerships/elements/partnerships-overview.html
+++ b/dash/app/views/partnerships/elements/partnerships-overview.html
@@ -454,10 +454,10 @@
       }
 
       _init(active, sectors, requiredDataLoaded) {
-        let params = this.queryParams;
         if (!active || !sectors || !requiredDataLoaded) {
           return;
         }
+        let params = this.queryParams;
         this.set('initComplete', false);
         this.set('qs', params.qs ? params.qs : '');
         this.set('pageNumber', params.page ? parseInt(params.page) : 1);
@@ -544,6 +544,10 @@
               selectedValue: map(prop('name'), this.selectedPartners)
             },
             {
+              filterName: 'Outstanding DCT >9?',
+              selectedValue: this.selectedOutstanding
+            },
+            {
               filterName: 'Partner Type',
               selectedValue: map(prop('value'), this.selectedTypes)  
             }
@@ -572,7 +576,7 @@
 
       _updateUrl(query, pageNumber, pageSize, sortOrder, orderBy, requiredDataLoaded,
         initComplete, selectedSectors, selectedPartners, selectedOutstanding, selectedTypes) {
-        if (!this.active || !this.initComplete || !this.requiredDataLoaded) {
+        if ( !this.active || !this.initComplete || !this.requiredDataLoaded) {
           return;
         }
         const qs = this.buildQueryString();

--- a/dash/app/views/partnerships/view-partnerships.html
+++ b/dash/app/views/partnerships/view-partnerships.html
@@ -50,11 +50,12 @@
       }
     </style>
 
-    <app-route route="{{route}}"
-               pattern="/dash/partnerships/:partnershipsTab"
+    <app-route route="[[route]]"
+               pattern="/:partnershipsTab"
                data="{{routeData}}"
                active="{{active}}"
-               query-params="{{queryParams}}"></app-route>
+               query-params="{{queryParams}}"
+               tail="{{subroute}}"></app-route>
 
     <div class="view-toggle">
       <paper-button id="overview" on-tap="_toggleDashView" name="overview" noink class="curved-left">
@@ -134,11 +135,17 @@
           },
           csoActive: {
             type: Boolean,
-            value: false
+            value: false,
+            notify: true
           },
           overviewActive: {
             type: Boolean,
-            value: false
+            value: false,
+            notify: true
+          },
+          route: {
+            type: Object,
+            notify: true
           }
         }
       }
@@ -157,11 +164,10 @@
           this.set('csvDownloadUrl', this.csvDownloadUrlOverview);
           this.$.overview.classList.remove('dark-button');
           this.$.csoDash.classList.remove('light-button');
-        } else {
+        } else if (tab === 'cso') {
           this.set('csoActive', true);
           this.set('overviewActive', false);
           this.set('csvDownloadUrl', this.csvDownloadUrlCso)
-          this.updateAppState(this.route.path);
           this.$.overview.classList.add('dark-button');
           this.$.csoDash.classList.add('light-button');
         }


### PR DESCRIPTION
@marko911 so this at least fixes the symptom of the problem I think.

if you go to staging/prod, start on personalized dash, then do a hard refresh. click on hact. the address bar should read `https://etools-staging.unicef.org/dash/hact/assurance?size=10&sort=asc`.

now click on partnerships. the address bar will read `https://etools-staging.unicef.org/dash/partnerships/assurance?page=1&size=10&sort=asc&outstanding=false`

obviously the `assurance` bit should not be part of the partnerships url. and this in combination with a couple other things leads to the global loading spinner going nonstop, which it should be doing at this point (stuck on "Loading partnerships data...").

this PR should stop that problem. i agree we should address the way we handle loading in a more systematic way using the mixins. will work on that ASAP, but this should address the issue that has been raised by users.