### PR TITLE
[ch24815] [Fixes] Use old content for 'Partnerships' tab and migrate to Polymer 3

### DIFF
--- a/src_ts/views/partnerships/elements/partnerships-overview.ts
+++ b/src_ts/views/partnerships/elements/partnerships-overview.ts
@@ -243,7 +243,7 @@ export class PartnershipsOverview extends connect(store)(CommonGeneralMixin(
           <div slot="row-data">
             <div class="col-3">
               [[row.vendor_number]]<br>
-              <a class="blue-text" href="[[baseSite]]/pmp/partners/[[row.id]]/details"
+              <a href="[[baseSite]]/pmp/partners/[[row.id]]/details"
                 app-name="pmp"
                 page="partners"
                 id="[[row.id]]/details"


### PR DESCRIPTION
[ch24815] [Fixes] Use old content for 'Partnerships' tab and migrate to Polymer 3